### PR TITLE
Fix mobile layout and intro header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -242,6 +242,10 @@ body {
   background-color: var(--secondary-bg);
 }
 
+.workflow-details-btn:active {
+  background-color: var(--secondary-bg);
+}
+
 /* Workflow page header banner styling */
 .workflow-header {
   background-color: var(--card-bg);
@@ -283,35 +287,46 @@ body {
   color: #D1D5DB !important; /* Lighter gray on hover */
 }
 
+[data-theme="dark"] .workflow-details-btn:active {
+  background-color: var(--secondary-bg);
+  color: #D1D5DB !important;
+}
+
 /* Workflow row hover states */
 .workflow-row {
   transition: all 0.2s ease;
 }
 
-.workflow-row:hover {
+.workflow-row:hover,
+.workflow-row:active {
   background-color: var(--secondary-bg);
 }
 
 /* Dark mode workflow row hover - when hovered, text should be dark for contrast */
-[data-theme="dark"] .workflow-row:hover .text-headline {
+[data-theme="dark"] .workflow-row:hover .text-headline,
+[data-theme="dark"] .workflow-row:active .text-headline {
   color: #1F2937 !important; /* Dark text on light hover background */
 }
 
-[data-theme="dark"] .workflow-row:hover .text-body {
+[data-theme="dark"] .workflow-row:hover .text-body,
+[data-theme="dark"] .workflow-row:active .text-body {
   color: #374151 !important; /* Dark gray text on light hover background */
 }
 
-[data-theme="dark"] .workflow-row:hover .text-accent-dark {
+[data-theme="dark"] .workflow-row:hover .text-accent-dark,
+[data-theme="dark"] .workflow-row:active .text-accent-dark {
   color: #1F2937 !important; /* Dark text on light hover background */
 }
 
 /* Keep teal accent visible on hover */
-[data-theme="dark"] .workflow-row:hover .text-accent-teal {
+[data-theme="dark"] .workflow-row:hover .text-accent-teal,
+[data-theme="dark"] .workflow-row:active .text-accent-teal {
   color: #0D9488 !important; /* Keep teal visible */
 }
 
 /* Workflow details button on hovered row */
-[data-theme="dark"] .workflow-row:hover .workflow-details-btn {
+[data-theme="dark"] .workflow-row:hover .workflow-details-btn,
+[data-theme="dark"] .workflow-row:active .workflow-details-btn {
   background-color: #FFFFFF;
   color: #374151 !important;
   border-color: #D1D5DB;
@@ -352,11 +367,5 @@ body {
 }
 
 .deployment-arrow {
-  display: none;
-}
-
-@media (min-width: 640px) {
-  .deployment-arrow {
-    display: block;
-  }
+  display: block;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,13 +64,20 @@ export default function Home() {
             </div>
           </div>
 
+          {/* Welcome Header */}
+          <div className="flex justify-center mb-6">
+            <div className="w-full max-w-4xl mx-auto">
+              <h3 className="text-2xl font-bold text-headline text-center">Welcome</h3>
+            </div>
+          </div>
+
           {/* Introduction Text in Paper Container */}
           <div className="flex justify-center mb-6">
             <div className="w-full max-w-4xl mx-auto" style={{ maxWidth: Math.min(800, typeof window !== 'undefined' ? window.innerWidth - 40 : 800) }}>
               <div className="paper-container p-8 mb-6">
                 <div className="text-left relative z-10">
                   <p className="text-body text-base leading-relaxed mb-6">
-                    Welcome, I build and run systems that people rely on — leading SRE teams, scaling infrastructure, and keeping environments secure and resilient.
+                    I build and run systems that people rely on — leading SRE teams, scaling infrastructure, and keeping environments secure and resilient.
                   </p>
                   <p className="text-body text-base leading-relaxed">
                     I'm passionate about Linux, open source, and using automation and AI to streamline operations and solve real-world problems. I enjoy mentoring engineers, improving systems through thoughtful design, and continuously learning to stay sharp for the next technical challenge.

--- a/app/workflows/page.tsx
+++ b/app/workflows/page.tsx
@@ -190,7 +190,7 @@ export default function WorkflowsPage() {
                         
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center space-x-3 mb-2">
-                            <h3 className="text-sm font-semibold text-headline truncate">
+                            <h3 className="text-sm font-semibold text-headline truncate max-w-[10rem] sm:max-w-none">
                               {workflow.name}
                             </h3>
                             <WorkflowStatusBadge status={workflow.status} />


### PR DESCRIPTION
## Summary
- ensure workflow overlay is legible and PR titles truncate on mobile
- display deployment arrows on all screen sizes
- move "Welcome" into its own header

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780c7ef510832fbc3011c4c5dc22e5