### PR TITLE
Dynamic repo name in workflows page

### DIFF
--- a/app/workflows/page.tsx
+++ b/app/workflows/page.tsx
@@ -63,6 +63,8 @@ export default function WorkflowsPage() {
   const [loading, setLoading] = useState(true)
   const [selectedWorkflow, setSelectedWorkflow] = useState<string>('all')
 
+  const repoName = process.env.NEXT_PUBLIC_REPO_NAME || 'this repository'
+
   // Fetch actual workflow runs from GitHub API
   useEffect(() => {
     const fetchWorkflows = async () => {
@@ -267,7 +269,7 @@ export default function WorkflowsPage() {
               <div className="p-4 border-b border-secondary-bg">
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-medium text-headline">
-                    Recent Commits That Triggered Workflows ({filteredWorkflows.length})
+                    Recent Commits on {repoName} ({filteredWorkflows.length})
                   </h2>
                 </div>
               </div>

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,24 @@
 /** @type {import('next').NextConfig} */
+const child_process = require('child_process')
+
+let repoName = 'repository'
+try {
+  const originUrl = child_process
+    .execSync('git config --get remote.origin.url')
+    .toString()
+    .trim()
+  repoName = originUrl.split('/').pop().replace(/\.git$/, '')
+} catch (e) {
+  console.warn('Could not determine repository name:', e)
+}
+
 const nextConfig = {
   // Enable standalone output for Docker optimization
   output: 'standalone',
+
+  env: {
+    NEXT_PUBLIC_REPO_NAME: repoName,
+  },
   
   // Preserve existing webpack config for PDF handling
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- expose repo name via NEXT_PUBLIC_REPO_NAME in `next.config.js`
- show repo name on workflows page